### PR TITLE
Fix/max contratos por peticion

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,7 +7,7 @@ import { ContratosModule } from './contratos/contratos.module';
 @Module({
   imports: [
     ConfigModule.forRoot({
-      envFilePath: ['.env.local', '.env.dev', '.env'],
+      envFilePath: ['.env.local', '.env.dev', '.env.production'],
       isGlobal: true,
     }),
     MongooseModule.forRoot(process.env.DATABASE_URL),

--- a/src/boe/boe.service.ts
+++ b/src/boe/boe.service.ts
@@ -4,9 +4,11 @@ import { Anuncio, Sumario } from '../compartido/api-models';
 import { BoeApiService } from '../compartido/boe-api.service';
 import { ContratoRepository } from '../compartido/contrato.repository';
 import { Boe, Contrato } from '../compartido/models';
+import { dividirEn } from '../utils';
 
 @Injectable()
 export class BoeService {
+  private readonly MAXIMO_CONTRATOS_POR_GRUPO = 50;
   constructor(private boeApi: BoeApiService, private repositorio: ContratoRepository) {}
 
   public obtenerBoe(id: string): Observable<Boe> {
@@ -29,14 +31,26 @@ export class BoeService {
     return this.repositorio.guardarContrato(contrato);
   }
 
+  // Nota: Por lo visto si intentamos resolver más de 50 contratos en una coleccion la libreria de xml2json falla.
   public async guardarContratosPorBoeId(id: string): Promise<number> {
     try {
       const { idContratos } = await firstValueFrom(this.boeApi.obtenerBoe(id));
-      const promisesDeContratos = idContratos.map((idC) => firstValueFrom(this.boeApi.obtenerContrato(idC)));
-      const contratos = await Promise.all(promisesDeContratos);
+      console.log(`Boe con ${idContratos.length} id's de contratos`);
+
+      const gruposDeContratos = dividirEn(this.MAXIMO_CONTRATOS_POR_GRUPO, idContratos);
+      const contratos = [];
+
+      for (let index = 0; index < gruposDeContratos.length; index++) {
+        console.log(`Grupo ${index} con ${gruposDeContratos[index].length} contratos`);
+        const parte = gruposDeContratos[index];
+        const promisesDeContratos = parte.map((idC) => firstValueFrom(this.boeApi.obtenerContrato(idC)));
+        contratos.push(...(await Promise.all(promisesDeContratos)));
+      }
+
       const totalDeContratosGuardados = this.repositorio.guardarContratos(contratos);
       return totalDeContratosGuardados;
     } catch (err) {
+      console.log('Guardados 0 contratos');
       console.log(`Error con el id [${id}]:`, err);
       return 0;
     }

--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -1,3 +1,4 @@
+import { dividirEn } from '.';
 import { Descripcion, ListaDeDefinicion } from '../compartido/api-models';
 import { Lote } from '../compartido/models';
 import {
@@ -126,5 +127,27 @@ describe('Utils specs', () => {
     expect(tituloMapper('prefijo : titulo sufijo')).toEqual('');
     expect(tituloMapper('prefijo  titulo. sufijo')).toEqual('');
     expect(tituloMapper('Objeto: titulo. Expediente')).toEqual('titulo.');
+  });
+
+  it('Divide en varios grupos una coleccion', () => {
+    const itemsPorGrupo = 2;
+
+    const coleccionImpar = [1, 2, 3, 4, 5];
+    const resultadoImpar = [[1, 2], [3, 4], [5]];
+
+    const coleccionPar = [1, 2, 3, 4, 5, 6];
+    const resultadoPar = [
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ];
+
+    expect(dividirEn(0, coleccionImpar)).toStrictEqual([]);
+    expect(dividirEn(-1, coleccionImpar)).toStrictEqual([]);
+    expect(dividirEn(itemsPorGrupo, [])).toStrictEqual([]);
+    expect(dividirEn(itemsPorGrupo, coleccionImpar)).toStrictEqual(resultadoImpar);
+    expect(dividirEn(itemsPorGrupo, coleccionImpar)).toStrictEqual(resultadoImpar);
+    expect(dividirEn(itemsPorGrupo, coleccionPar)).toStrictEqual(resultadoPar);
+    expect(dividirEn(10, coleccionImpar)).toStrictEqual([coleccionImpar]);
   });
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -130,3 +130,18 @@ export const fechaPublicacionMapper = (fecha: string): string => {
     return '';
   }
 };
+
+// Divide una coleccion en varios grupos de tamaño `itemsPorGrupo`
+export const dividirEn = <T>(itemsPorGrupo: number, coleccion: T[]): T[][] => {
+  if (itemsPorGrupo <= 0 || coleccion.length == 0) return [];
+  const copia = [...coleccion];
+  const resultado = [];
+
+  let i,
+    j = 0;
+  for (i = 0, j = copia.length; i < j; i += itemsPorGrupo) {
+    resultado.push(copia.slice(i, i + itemsPorGrupo));
+  }
+
+  return resultado;
+};


### PR DESCRIPTION
La libreria xml2json daba error cuando se intentaba parsear más de 50 contratos mas o menos, así que ahora se subdividen en grupos de 50 y se van parseando poco a poco y luego se guardan todos 